### PR TITLE
add GROQ_API_KEY

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,6 +62,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr,prefix=pr-{{sha}}-
+            type=ref,event=tag
       - name: Build
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         id: push


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Inject the GROQ_API_KEY secret into the Docker container environment in .github/workflows/docker.yaml