### PR TITLE
Use WolfiOS

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,7 @@ jobs:
       image_tag: ${{ steps.meta.outputs.tags }}
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Log in to the Container registry

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,8 +40,8 @@ jobs:
     outputs:
       image_tag: ${{ steps.meta.outputs.tags }}
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
+    #   - name: Free Disk Space
+    #     uses: jlumbroso/free-disk-space@v1.3.1
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Log in to the Container registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM python:3.13@sha256:28f60ab75da2183870846130cead1f6af30162148d3238348f78f89cf6160b5d AS builder
-
-SHELL ["/bin/bash", "-c"]
+FROM cgr.dev/chainguard/wolfi-base AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
-    UV_PYTHON_DOWNLOADS=0
+    UV_PYTHON_PREFERENCE=only-managed
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:2fd1b38e3398a256d6af3f71f0e2ba6a517b249998726a64d8cfbe55ab34af5e \
     /uv /uvx /bin/
@@ -22,25 +20,18 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --locked --no-editable
 
-FROM python:3.13-slim@sha256:6544e0e002b40ae0f59bc3618b07c1e48064c4faed3a15ae2fbd2e8f663e8283 AS production
-
-SHELL ["/bin/bash", "-c"]
+FROM cgr.dev/chainguard/wolfi-base AS production
 
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0
 
-RUN groupadd app && \
-    useradd -m -g app -s /bin/bash app && \
-    apt-get update > /dev/null && \
-    apt-get install -y --no-install-recommends curl > /dev/null && \
-    apt-get clean > /dev/null && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl
 
-WORKDIR /home/app
+USER nonroot
 
-COPY --from=builder --chown=app:app --chmod=555 /app/.venv /app/.venv
+# WORKDIR /home/nonroot
 
-USER app
+COPY --from=builder --chown=nonroot:nonroot --chmod=555 /app/.venv /app/.venv
 
 EXPOSE ${GRADIO_SERVER_PORT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ ENV UV_LINK_MODE=copy \
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:2fd1b38e3398a256d6af3f71f0e2ba6a517b249998726a64d8cfbe55ab34af5e \
     /uv /uvx /bin/
 
+USER nonroot
+
 WORKDIR /app
 
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,target=/home/nonroot/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
@@ -17,7 +19,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 COPY . /app
 
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,target=/home/nonroot/.cache/uv \
     uv sync --no-dev --locked --no-editable
 
 FROM cgr.dev/chainguard/wolfi-base:latest AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV UV_LINK_MODE=copy \
     UV_PYTHON_PREFERENCE=only-managed
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:2fd1b38e3398a256d6af3f71f0e2ba6a517b249998726a64d8cfbe55ab34af5e \
-    /uv /uvx /bin/
+    /uv /uvx /usr/bin/
 
 USER nonroot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
@@ -20,7 +20,7 @@ COPY . /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --locked --no-editable
 
-FROM cgr.dev/chainguard/wolfi-base AS production
+FROM cgr.dev/chainguard/wolfi-base:latest AS production
 
 ENV GRADIO_SERVER_PORT=7860 \
     GRADIO_SERVER_NAME=0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM cgr.dev/chainguard/wolfi-base:latest AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
-    UV_PYTHON_PREFERENCE=only-managed
+    UV_PYTHON_PREFERENCE=only-managed \
+    UV_PYTHON_INSTALL_DIR=/home/nonroot/python
 
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:2fd1b38e3398a256d6af3f71f0e2ba6a517b249998726a64d8cfbe55ab34af5e \
     /uv /uvx /usr/bin/
@@ -31,7 +32,9 @@ RUN apk add --no-cache curl
 
 USER nonroot
 
-# WORKDIR /home/nonroot
+WORKDIR /home/nonroot
+
+COPY --from=builder --chown=nonroot:nonroot /home/nonroot/python /home/nonroot/python
 
 COPY --from=builder --chown=nonroot:nonroot --chmod=555 /app/.venv /app/.venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base AS builder
+FROM cgr.dev/chainguard/wolfi-base@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/wolfi-base:latest@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef AS builder
+FROM cgr.dev/chainguard/wolfi-base:latest AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ USER nonroot
 
 WORKDIR /app
 
-RUN --mount=type=cache,target=/home/nonroot/.cache/uv \
+RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/home/nonroot/.cache/uv \
 
 COPY . /app
 
-RUN --mount=type=cache,target=/home/nonroot/.cache/uv \
+RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-dev --locked --no-editable
 
 FROM cgr.dev/chainguard/wolfi-base:latest AS production


### PR DESCRIPTION
## Summary by Sourcery

Migrate the Dockerfile to use Wolfi OS base images and simplify the build and production stages

Enhancements:
- Use Wolfi OS wolfi-base as the base image for both builder and production
- Replace apt-get steps with apk to install curl in the production stage
- Adopt the built-in nonroot user instead of manually creating an app user
- Update UV environment variables to prefer managed Python packages
- Remove custom SHELL directives and unify command syntax across stages