### PR TITLE
Remove FileHandler from logger configuration

### DIFF
--- a/src/chattr/app/logger.py
+++ b/src/chattr/app/logger.py
@@ -1,5 +1,4 @@
-from logging import INFO, WARNING, FileHandler, Logger, basicConfig, getLogger
-from pathlib import Path
+from logging import INFO, WARNING, Logger, basicConfig, getLogger
 
 from rich.logging import RichHandler
 
@@ -13,7 +12,6 @@ basicConfig(
             console=console,
             rich_tracebacks=True,
         ),
-        FileHandler(Path.cwd() / "logs" / APP_NAME / "chattr.log", delay=True),
     ],
     format="%(name)s | %(process)d | %(message)s",
 )

--- a/src/chattr/app/settings.py
+++ b/src/chattr/app/settings.py
@@ -16,7 +16,6 @@ from pydantic import (
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from chattr import APP_NAME
 from chattr.app.logger import logger
 from chattr.app.scheme import MCPScheme
 
@@ -72,12 +71,6 @@ class DirectorySettings(BaseModel):
 
     @computed_field
     @property
-    def log(self) -> DirectoryPath:
-        """Path to the log directory."""
-        return self.base / "logs" / APP_NAME
-
-    @computed_field
-    @property
     def assets(self) -> DirectoryPath:
         """Path to the assets directory."""
         return self.base / "assets"
@@ -110,14 +103,7 @@ class DirectorySettings(BaseModel):
         Returns:
             Self: The validated DirectorySettings instance.
         """
-        for directory in [
-            self.base,
-            self.assets,
-            self.log,
-            self.audio,
-            self.video,
-            self.prompts,
-        ]:
+        for directory in [self.base, self.assets, self.audio, self.video, self.prompts]:
             if not directory.exists():
                 try:
                     directory.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Eliminate the FileHandler from the logger setup to streamline logging configuration and remove unnecessary dependencies. Adjust related code to ensure proper functionality without the log file handler.

## Summary by Sourcery

Remove file-based logging and associated log directory usage from the application configuration.

Enhancements:
- Stop configuring a FileHandler in the logger so logging only outputs to the rich console.
- Remove the computed log directory path and exclude it from automatic directory creation.